### PR TITLE
feat: add TrendPill widget for stats feature

### DIFF
--- a/assets/images/icons/trend-up-icon.svg
+++ b/assets/images/icons/trend-up-icon.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M11 1L7.5 4.5L5.5 2.5L1 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M8 1H11V4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/features/stats/presentation/constants/stats_screen_constants.dart
+++ b/lib/features/stats/presentation/constants/stats_screen_constants.dart
@@ -1,5 +1,12 @@
+import 'dart:ui';
+
 /// Constantes especificas del feature de estadisticas.
 abstract class StatsScreenConstants {
+  // --- Trend pill ---
+  static const String trendUpIcon = 'assets/images/icons/trend-up-icon.svg';
+  static const Color trendPositiveColor = Color(0xFF16A34A);
+  static const Color trendPositiveBackground = Color(0xFFF0FDF4);
+
   // --- Shadow del badge (specs unicas de este feature) ---
   static const double badgeShadowBlur = 2.0;
   static const double badgeShadowOffsetY = 1.0;

--- a/lib/features/stats/presentation/widgets/trend_pill.dart
+++ b/lib/features/stats/presentation/widgets/trend_pill.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/features/stats/presentation/constants/stats_screen_constants.dart';
+
+
+/// Atomo: Pill que muestra una tendencia porcentual con icono y texto.
+class TrendPill extends StatelessWidget {
+  const TrendPill({
+    required this.percentage,
+    super.key,
+  });
+
+  final int percentage;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: StatsScreenConstants.trendPositiveBackground,
+        borderRadius: BorderRadius.circular(BorderRadiusConstants.small),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: SpacingConstants.xs,
+          horizontal: SpacingConstants.small,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: SpacingConstants.xs,
+          children: [
+            SvgPicture.asset(
+              StatsScreenConstants.trendUpIcon,
+              colorFilter: const ColorFilter.mode(
+                StatsScreenConstants.trendPositiveColor,
+                BlendMode.srcIn,
+              ),
+            ),
+            Text(
+              '+$percentage%',
+              style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                    color: StatsScreenConstants.trendPositiveColor,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 🎯 ¿Qué hace este PR?
Agrega el widget TrendPill (átomo) que muestra una tendencia porcentual con icono SVG y texto. Recibe un entero y arma el formato `+N%` internamente.

## 🔗 Task Relacionada
Closes #47

## 🛠️ Tipo de Cambio
- [x] ✨ Nueva Feature (Pantalla, Lógica, etc.)
- [ ] 🐛 Bugfix (Corrección de errores)
- [x] 💄 UI/UX (Cambios visuales, animaciones)
- [ ] 🏗️ Refactor/Arquitectura

## 📸 Pruebas Visuales (Screenshots / GIFs)

<img width="145" height="137" alt="Captura de pantalla 2026-03-23 a las 1 45 06 p  m" src="https://github.com/user-attachments/assets/11d43adf-4015-4cc8-aaa9-5bcc5f0ee6cf" />

## ✅ Checklist (Criterios de Aceptación)
- [x] Mi código compila sin errores (`flutter run`).
- [x] Formateé el código con `dart format .`
- [x] No dejé `print()` sueltos (usé `debugPrint` si era estrictamente necesario).
- [ ] Probé la navegación hacia atrás (si aplica).