### PR TITLE
feat: Weekly Bar Chart widget - ticket #50

### DIFF
--- a/lib/features/stats/presentation/constants/stats_screen_constants.dart
+++ b/lib/features/stats/presentation/constants/stats_screen_constants.dart
@@ -7,6 +7,14 @@ abstract class StatsScreenConstants {
   static const Color trendPositiveColor = Color(0xFF16A34A);
   static const Color trendPositiveBackground = Color(0xFFF0FDF4);
 
+  // --- Weekly bar chart ---
+  static const double chartHeight = 128.0;
+  static const int barMaxActions = 20;
+  static const double barActiveOpacity = 1.0;
+  static const double barFutureOpacity = 0.5;
+  static const double barBackgroundOpacity = 0.1;
+  static const Color dayLabelColor = Color(0xFF94A3B8);
+
   // --- Shadow del badge (specs unicas de este feature) ---
   static const double badgeShadowBlur = 2.0;
   static const double badgeShadowOffsetY = 1.0;

--- a/lib/features/stats/presentation/widgets/day_bar.dart
+++ b/lib/features/stats/presentation/widgets/day_bar.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:wize_cards/core/utils/color_constants.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/features/stats/presentation/constants/stats_screen_constants.dart';
+
+/// Atomo: Barra individual de un dia en el grafico semanal.
+///
+/// Muestra una barra proporcional al valor del dia con label debajo.
+/// Dias pasados en azul fuerte, dias futuros en azul al 50%.
+class DayBar extends StatelessWidget {
+  const DayBar({
+    required this.value,
+    required this.maxValue,
+    required this.label,
+    required this.isPast,
+    required this.isCurrentDay,
+    super.key,
+  });
+
+  final int value;
+  final int maxValue;
+  final String label;
+  final bool isPast;
+  final bool isCurrentDay;
+
+  @override
+  Widget build(BuildContext context) {
+    final fillRatio = maxValue > 0 ? value.toDouble() / maxValue : 0.0;
+    final barOpacity = isPast || isCurrentDay
+        ? StatsScreenConstants.barActiveOpacity
+        : StatsScreenConstants.barFutureOpacity;
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final totalHeight = constraints.maxHeight;
+              final fillHeight = totalHeight * fillRatio;
+
+              return Stack(
+                alignment: Alignment.bottomCenter,
+                children: [
+                  DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: ColorConstants.primaryBlue.withValues(
+                        alpha: StatsScreenConstants.barBackgroundOpacity,
+                      ),
+                      borderRadius: BorderRadius.vertical(
+                        top: Radius.circular(BorderRadiusConstants.medium),
+                      ),
+                    ),
+                    child: const SizedBox.expand(),
+                  ),
+                  SizedBox(
+                    height: fillHeight,
+                    width: double.infinity,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: ColorConstants.primaryBlue.withValues(
+                          alpha: barOpacity,
+                        ),
+                        borderRadius: BorderRadius.vertical(
+                          top: Radius.circular(BorderRadiusConstants.medium),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+        SizedBox(height: SpacingConstants.small),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                fontWeight: FontWeight.w500,
+                color: isCurrentDay
+                    ? ColorConstants.textPrimary
+                    : StatsScreenConstants.dayLabelColor,
+              ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stats/presentation/widgets/day_bar.dart
+++ b/lib/features/stats/presentation/widgets/day_bar.dart
@@ -25,7 +25,8 @@ class DayBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final fillRatio = maxValue > 0 ? value.toDouble() / maxValue : 0.0;
+    final fillRatio =
+        maxValue > 0 ? (value.toDouble() / maxValue).clamp(0.0, 1.0) : 0.0;
     final barOpacity = isPast || isCurrentDay
         ? StatsScreenConstants.barActiveOpacity
         : StatsScreenConstants.barFutureOpacity;

--- a/lib/features/stats/presentation/widgets/weekly_bar_chart.dart
+++ b/lib/features/stats/presentation/widgets/weekly_bar_chart.dart
@@ -20,8 +20,6 @@ class WeeklyBarChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final maxValue = weeklyData.reduce((a, b) => a > b ? a : b);
-
     return SizedBox(
       height: StatsScreenConstants.chartHeight,
       child: Row(
@@ -30,7 +28,7 @@ class WeeklyBarChart extends StatelessWidget {
           return Expanded(
             child: DayBar(
               value: weeklyData[index],
-              maxValue: maxValue,
+              maxValue: StatsScreenConstants.barMaxActions,
               label: _dayLabels[index],
               isPast: index < currentDayIndex,
               isCurrentDay: index == currentDayIndex,

--- a/lib/features/stats/presentation/widgets/weekly_bar_chart.dart
+++ b/lib/features/stats/presentation/widgets/weekly_bar_chart.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:wize_cards/features/stats/presentation/constants/stats_screen_constants.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/day_bar.dart';
+
+/// Organismo: Grafico de barras semanal que muestra actividad por dia.
+///
+/// Recibe datos semanales y el indice del dia actual para resaltar
+/// dias pasados vs futuros.
+class WeeklyBarChart extends StatelessWidget {
+  const WeeklyBarChart({
+    required this.weeklyData,
+    required this.currentDayIndex,
+    super.key,
+  });
+
+  final List<int> weeklyData;
+  final int currentDayIndex;
+
+  static const _dayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+  @override
+  Widget build(BuildContext context) {
+    final maxValue = weeklyData.reduce((a, b) => a > b ? a : b);
+
+    return SizedBox(
+      height: StatsScreenConstants.chartHeight,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: List.generate(weeklyData.length, (index) {
+          return Expanded(
+            child: DayBar(
+              value: weeklyData[index],
+              maxValue: maxValue,
+              label: _dayLabels[index],
+              isPast: index < currentDayIndex,
+              isCurrentDay: index == currentDayIndex,
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -721,10 +721,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## 🎯 ¿Qué hace este PR?
Agrega el gráfico de barras semanal (WeeklyBarChart) compuesto por DayBar atoms. Muestra 7 barras proporcionales con días pasados en azul fuerte, día actual con label bold, y días futuros en azul claro.

## 🔗 Task Relacionada
Closes #50

## 🛠️ Tipo de Cambio
- [x] ✨ Nueva Feature (Pantalla, Lógica, etc.)
- [ ] 🐛 Bugfix (Corrección de errores)
- [x] 💄 UI/UX (Cambios visuales, animaciones)
- [ ] 🏗️ Refactor/Arquitectura

## 📸 Pruebas Visuales (Screenshots / GIFs)
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-03-23 at 17 17 26" src="https://github.com/user-attachments/assets/ee1f5551-37f9-4b7a-95e3-68871c3c3d12" />


## ✅ Checklist (Criterios de Aceptación)
- [x] Mi código compila sin errores (`flutter run`).
- [x] Formateé el código con `dart format .`
- [x] No dejé `print()` sueltos (usé `debugPrint` si era estrictamente necesario).
- [ ] Probé la navegación hacia atrás (si aplica).