### PR TITLE
feat: add StatsProvider with mock data and BadgeModel

### DIFF
--- a/lib/data/models/badge_model.dart
+++ b/lib/data/models/badge_model.dart
@@ -1,0 +1,17 @@
+import 'dart:ui';
+
+class BadgeModel {
+  final String iconPath;
+  final String label;
+  final Color color;
+  final List<Color> gradientColors;
+  final bool isUnlocked;
+
+  const BadgeModel({
+    required this.iconPath,
+    required this.label,
+    required this.color,
+    required this.gradientColors,
+    this.isUnlocked = false,
+  });
+}

--- a/lib/features/stats/presentation/bloc/stats_bloc.dart
+++ b/lib/features/stats/presentation/bloc/stats_bloc.dart
@@ -1,0 +1,68 @@
+import 'dart:ui';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wize_cards/core/utils/color_constants.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/data/models/badge_model.dart';
+import 'package:wize_cards/features/stats/presentation/bloc/stats_event.dart';
+import 'package:wize_cards/features/stats/presentation/bloc/stats_state.dart';
+
+class StatsBloc extends Bloc<StatsEvent, StatsState> {
+  StatsBloc() : super(StatsInitial()) {
+    on<StatsLoadRequested>(_onLoadRequested);
+    on<StatsRefreshRequested>(_onRefreshRequested);
+  }
+
+  Future<void> _onLoadRequested(
+    StatsLoadRequested event,
+    Emitter<StatsState> emit,
+  ) async {
+    emit(StatsLoading());
+    emit(_loadMockData());
+  }
+
+  Future<void> _onRefreshRequested(
+    StatsRefreshRequested event,
+    Emitter<StatsState> emit,
+  ) async {
+    emit(StatsLoading());
+    emit(_loadMockData());
+  }
+
+  /// Datos mock. Sera reemplazado por un UseCase cuando exista la API.
+  StatsLoaded _loadMockData() {
+    return StatsLoaded(
+      weeklyActions: 24,
+      trendPercentage: 12,
+      cardsCollected: 120,
+      currentStreak: 5,
+      weeklyData: const [12, 8, 18, 5, 24, 4, 2],
+      currentDayIndex: DateTime.now().weekday - 1,
+      badges: const [
+        BadgeModel(
+          iconPath: AppConstants.starterIcon,
+          label: 'Starter',
+          color: ColorConstants.primaryBlue,
+          gradientColors: [Color(0xFFDBEAFE), Color(0xFFEFF6FF)],
+          isUnlocked: true,
+        ),
+        BadgeModel(
+          iconPath: AppConstants.socialIcon,
+          label: 'Social',
+          color: ColorConstants.dotGreen,
+          gradientColors: [Color(0xFFDCFCE7), Color(0xFFF0FDF4)],
+          isUnlocked: true,
+        ),
+        BadgeModel(
+          iconPath: AppConstants.masterIcon,
+          label: 'Master',
+          color: ColorConstants.iconDisabled,
+          gradientColors: [
+            ColorConstants.backgroundLightGrey,
+            ColorConstants.backgroundLightGrey,
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stats/presentation/bloc/stats_event.dart
+++ b/lib/features/stats/presentation/bloc/stats_event.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+abstract class StatsEvent extends Equatable {
+  const StatsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Carga inicial de los datos de estadisticas.
+class StatsLoadRequested extends StatsEvent {}
+
+/// Refresca los datos de estadisticas.
+class StatsRefreshRequested extends StatsEvent {}

--- a/lib/features/stats/presentation/bloc/stats_state.dart
+++ b/lib/features/stats/presentation/bloc/stats_state.dart
@@ -1,0 +1,57 @@
+import 'package:equatable/equatable.dart';
+import 'package:wize_cards/data/models/badge_model.dart';
+
+abstract class StatsState extends Equatable {
+  const StatsState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Estado inicial antes de cargar datos.
+class StatsInitial extends StatsState {}
+
+/// Cargando datos de estadisticas.
+class StatsLoading extends StatsState {}
+
+/// Datos cargados exitosamente.
+class StatsLoaded extends StatsState {
+  final int weeklyActions;
+  final int trendPercentage;
+  final int cardsCollected;
+  final int currentStreak;
+  final List<int> weeklyData;
+  final int currentDayIndex;
+  final List<BadgeModel> badges;
+
+  const StatsLoaded({
+    required this.weeklyActions,
+    required this.trendPercentage,
+    required this.cardsCollected,
+    required this.currentStreak,
+    required this.weeklyData,
+    required this.currentDayIndex,
+    required this.badges,
+  });
+
+  @override
+  List<Object?> get props => [
+    weeklyActions,
+    trendPercentage,
+    cardsCollected,
+    currentStreak,
+    weeklyData,
+    currentDayIndex,
+    badges,
+  ];
+}
+
+/// Error al cargar datos.
+class StatsError extends StatsState {
+  final String message;
+
+  const StatsError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/stats/presentation/providers/stats_provider.dart
+++ b/lib/features/stats/presentation/providers/stats_provider.dart
@@ -1,0 +1,43 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:wize_cards/core/utils/color_constants.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/data/models/badge_model.dart';
+
+class StatsProvider extends ChangeNotifier {
+  int weeklyActions = 24;
+  int trendPercentage = 12;
+  int cardsCollected = 120;
+  int currentStreak = 5;
+
+  List<int> weeklyData = [12, 8, 18, 5, 24, 4, 2];
+
+  int get currentDayIndex => DateTime.now().weekday - 1;
+
+  List<BadgeModel> badges = [
+    const BadgeModel(
+      iconPath: AppConstants.starterIcon,
+      label: 'Starter',
+      color: ColorConstants.primaryBlue,
+      gradientColors: [Color(0xFFDBEAFE), Color(0xFFEFF6FF)],
+      isUnlocked: true,
+    ),
+    const BadgeModel(
+      iconPath: AppConstants.socialIcon,
+      label: 'Social',
+      color: ColorConstants.dotGreen,
+      gradientColors: [Color(0xFFDCFCE7), Color(0xFFF0FDF4)],
+      isUnlocked: true,
+    ),
+    const BadgeModel(
+      iconPath: AppConstants.masterIcon,
+      label: 'Master',
+      color: ColorConstants.iconDisabled,
+      gradientColors: [
+        ColorConstants.backgroundLightGrey,
+        ColorConstants.backgroundLightGrey,
+      ],
+    ),
+  ];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,28 +43,24 @@ class MyApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => StatsProvider()),
+        BlocProvider<AuthBloc>.value(value: _authBloc),
       ],
-      child: MultiBlocProvider(
-        providers: [
-          BlocProvider<AuthBloc>.value(value: _authBloc),
-        ],
-        child: useGoRouter
-            ? MaterialApp.router(
-                title: 'WizeCards',
-                debugShowCheckedModeBanner: false,
-                theme: AppTheme.lightTheme,
-                themeMode: ThemeMode.light,
-                routerConfig: _router,
-              )
-            : MaterialApp(
-                title: 'WizeCards',
-                debugShowCheckedModeBanner: false,
-                theme: AppTheme.lightTheme,
-                themeMode: ThemeMode.light,
-                initialRoute: AppRoutes.splash,
-                onGenerateRoute: RouteGenerator.generateRoute,
-              ),
-      ),
+      child: useGoRouter
+          ? MaterialApp.router(
+              title: 'WizeCards',
+              debugShowCheckedModeBanner: false,
+              theme: AppTheme.lightTheme,
+              themeMode: ThemeMode.light,
+              routerConfig: _router,
+            )
+          : MaterialApp(
+              title: 'WizeCards',
+              debugShowCheckedModeBanner: false,
+              theme: AppTheme.lightTheme,
+              themeMode: ThemeMode.light,
+              initialRoute: AppRoutes.splash,
+              onGenerateRoute: RouteGenerator.generateRoute,
+            ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,13 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
-import 'package:provider/provider.dart';
 import 'package:wize_cards/core/router/app_routes.dart';
 import 'package:wize_cards/core/router/auth_session_notifier.dart';
 import 'package:wize_cards/core/router/route_generator.dart';
 import 'package:wize_cards/core/theme/app_theme.dart';
 import 'package:wize_cards/core/di/injection_container.dart' as di;
 import 'package:wize_cards/features/auth/presentation/bloc/auth_bloc.dart';
-import 'package:wize_cards/features/stats/presentation/providers/stats_provider.dart';
+import 'package:wize_cards/features/stats/presentation/bloc/stats_bloc.dart';
 import 'package:wize_cards/firebase_options.dart';
 
 void main() async {
@@ -40,10 +39,10 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiProvider(
+    return MultiBlocProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => StatsProvider()),
         BlocProvider<AuthBloc>.value(value: _authBloc),
+        BlocProvider<StatsBloc>(create: (_) => StatsBloc()),
       ],
       child: useGoRouter
           ? MaterialApp.router(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,12 +3,14 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 import 'package:wize_cards/core/router/app_routes.dart';
 import 'package:wize_cards/core/router/auth_session_notifier.dart';
 import 'package:wize_cards/core/router/route_generator.dart';
 import 'package:wize_cards/core/theme/app_theme.dart';
 import 'package:wize_cards/core/di/injection_container.dart' as di;
 import 'package:wize_cards/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:wize_cards/features/stats/presentation/providers/stats_provider.dart';
 import 'package:wize_cards/firebase_options.dart';
 
 void main() async {
@@ -38,26 +40,31 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
+    return MultiProvider(
       providers: [
-        BlocProvider<AuthBloc>.value(value: _authBloc)
+        ChangeNotifierProvider(create: (_) => StatsProvider()),
+      ],
+      child: MultiBlocProvider(
+        providers: [
+          BlocProvider<AuthBloc>.value(value: _authBloc),
         ],
-      child: useGoRouter
-          ? MaterialApp.router(
-              title: 'WizeCards',
-              debugShowCheckedModeBanner: false,
-              theme: AppTheme.lightTheme,
-              themeMode: ThemeMode.light,
-              routerConfig: _router,
-            )
-          : MaterialApp(
-              title: 'WizeCards',
-              debugShowCheckedModeBanner: false,
-              theme: AppTheme.lightTheme,
-              themeMode: ThemeMode.light,
-              initialRoute: AppRoutes.splash,
-              onGenerateRoute: RouteGenerator.generateRoute,
-            ),
+        child: useGoRouter
+            ? MaterialApp.router(
+                title: 'WizeCards',
+                debugShowCheckedModeBanner: false,
+                theme: AppTheme.lightTheme,
+                themeMode: ThemeMode.light,
+                routerConfig: _router,
+              )
+            : MaterialApp(
+                title: 'WizeCards',
+                debugShowCheckedModeBanner: false,
+                theme: AppTheme.lightTheme,
+                themeMode: ThemeMode.light,
+                initialRoute: AppRoutes.splash,
+                onGenerateRoute: RouteGenerator.generateRoute,
+              ),
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -553,7 +553,7 @@ packages:
     source: hosted
     version: "2.1.8"
   provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: provider
       sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   google_sign_in: ^6.2.1
   intl: ^0.20.2
   path: ^1.8.3
+  provider: ^6.1.5+1
   shared_preferences: ^2.5.4
   sqflite: ^2.3.0
   url_launcher: ^6.3.2


### PR DESCRIPTION
## 🎯 ¿Qué hace este PR?
Agrega el StatsProvider con datos mock para la pantalla de Stats y el modelo BadgeModel para los badges de logros.

## 🔗 Task Relacionada
Closes #51

## 🛠️ Tipo de Cambio
- [x] ✨ Nueva Feature (Pantalla, Lógica, etc.)
- [ ] 🐛 Bugfix (Corrección de errores)
- [ ] 💄 UI/UX (Cambios visuales, animaciones)
- [ ] 🏗️ Refactor/Arquitectura

## 📸 Pruebas Visuales (Screenshots / GIFs)
| Antes | Después |
| :---: | :---: |
| N/A | N/A (lógica sin UI) |

## ✅ Checklist (Criterios de Aceptación)
- [x] Mi código compila sin errores (`flutter run`).
- [x] Formateé el código con `dart format .`
- [x] No dejé `print()` sueltos (usé `debugPrint` si era estrictamente necesario).
- [ ] Probé la navegación hacia atrás (si aplica).