### PR TITLE
Feat: Create StudyHeaderWidget for Decks Tab

### DIFF
--- a/lib/features/deck/constanst/deck_screen_constant.dart
+++ b/lib/features/deck/constanst/deck_screen_constant.dart
@@ -12,6 +12,8 @@ abstract class DeckScreenConstants {
       "No decks found for the selected filter.";
   static const String cards = "cards";
   static const String lastStudied = "Last studied";
+  static const String sessionStateTitle = "Business Terms";
+  static const String progress = "Progress";
 
   static const double sizeCard = 92.0;
 }

--- a/lib/features/deck/widgets/study_header_widget.dart
+++ b/lib/features/deck/widgets/study_header_widget.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:wize_cards/core/presentation/widgets/buttons/ds_circular_icon_button_widget.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/features/deck/constanst/deck_screen_constant.dart';
+import 'package:wize_cards/features/deck/widgets/title_sesion_state_widget.dart';
+
+class StudyHeaderWidget extends StatelessWidget {
+  final double progress;
+  final double maxValue;
+  final VoidCallback onBackPressed;
+  final VoidCallback onSettingsPressed;
+  const StudyHeaderWidget({
+    super.key,
+    required this.progress,
+    required this.maxValue,
+    required this.onBackPressed,
+    required this.onSettingsPressed
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final normalizedProgress = (progress / maxValue).clamp(0.0, 1.0);
+
+    return Column(
+      children: [
+          Row(
+            mainAxisAlignment: .spaceBetween,
+            children: [
+              DsCircularIconButtonWidget(
+                onPressed: onBackPressed,
+                icon: Icons.arrow_back,
+                primary: theme.colorScheme.primary,
+                backgroundColor: Colors.white,
+              ),
+              TitleSesionStateWidget(title: DeckScreenConstants.sessionStateTitle),
+              DsCircularIconButtonWidget(
+                onPressed: onSettingsPressed,
+                icon: Icons.settings_outlined,
+                primary: theme.colorScheme.primary,
+                backgroundColor: Colors.white,
+              ),
+            ],
+          ),
+        SizedBox(
+          height: SpacingConstants.medium,
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: SpacingConstants.small),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: .spaceBetween,
+                children: [
+                  Text(
+                    DeckScreenConstants.progress,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      fontSize: TextSizeConstants.caption,
+                      color: theme.shadowColor
+                    ),
+                  ),
+                  Text(
+                    "${progress.toInt()} / ${maxValue.toInt()}",
+                     style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      fontSize: TextSizeConstants.body,
+                      color: Colors.blue
+                      ),
+                    ),
+                ],
+              ),
+              SizedBox(
+                height: SpacingConstants.xs,
+              ),
+              LinearProgressIndicator(
+                minHeight: ThicknessConstans.md,
+                value: normalizedProgress,
+                backgroundColor: theme.shadowColor,
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
+                borderRadius: BorderRadius.circular(
+                  BorderRadiusConstants.large,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/deck/widgets/study_header_widget.dart
+++ b/lib/features/deck/widgets/study_header_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:wize_cards/core/presentation/widgets/buttons/ds_circular_icon_button_widget.dart';
+import 'package:wize_cards/core/utils/color_constants.dart';
 import 'package:wize_cards/core/utils/constant.dart';
 import 'package:wize_cards/features/deck/constanst/deck_screen_constant.dart';
 import 'package:wize_cards/features/deck/widgets/title_sesion_state_widget.dart';
@@ -38,7 +39,7 @@ class StudyHeaderWidget extends StatelessWidget {
                 onPressed: onSettingsPressed,
                 icon: Icons.settings_outlined,
                 primary: theme.colorScheme.primary,
-                backgroundColor: Colors.white,
+                backgroundColor: ColorConstants.primaryWhite,
               ),
             ],
           ),
@@ -65,7 +66,7 @@ class StudyHeaderWidget extends StatelessWidget {
                      style: theme.textTheme.bodySmall?.copyWith(
                       fontWeight: FontWeight.bold,
                       fontSize: TextSizeConstants.body,
-                      color: Colors.blue
+                      color: ColorConstants.primaryBlue
                       ),
                     ),
                 ],
@@ -77,7 +78,7 @@ class StudyHeaderWidget extends StatelessWidget {
                 minHeight: ThicknessConstans.md,
                 value: normalizedProgress,
                 backgroundColor: theme.shadowColor,
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
+                valueColor: AlwaysStoppedAnimation<Color>(ColorConstants.primaryBlue),
                 borderRadius: BorderRadius.circular(
                   BorderRadiusConstants.large,
                 ),

--- a/lib/features/deck/widgets/title_sesion_state_widget.dart
+++ b/lib/features/deck/widgets/title_sesion_state_widget.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:wize_cards/core/utils/color_constants.dart';
 import 'package:wize_cards/core/utils/constant.dart';
 
-class TitleSesionStateWdiget extends StatelessWidget {
+class TitleSesionStateWidget extends StatelessWidget {
   final String title;
 
-  const TitleSesionStateWdiget({super.key, required this.title});
+  const TitleSesionStateWidget({super.key, required this.title});
 
   @override
   Widget build(BuildContext context) {
@@ -35,9 +35,10 @@ class TitleSesionStateWdiget extends StatelessWidget {
                 ),
               ),
             ),
-            Text(TextConstans.liveSession, 
-            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                fontSize: TextSizeConstants.caption
+            Text(
+              TextConstans.liveSession,
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                fontSize: TextSizeConstants.caption,
               ),
             ),
           ],


### PR DESCRIPTION
## 🎯 ¿Qué hace este PR?
Study Header Widget Integration
## 🔗 Task Relacionada
https://github.com/Stivenmore/Wize-Cards/issues/39
Closes #

## 🛠️ Tipo de Cambio
- [x] ✨ Nueva Feature (Pantalla, Lógica, etc.)
- [ ] 🐛 Bugfix (Corrección de errores)
- [ ] 💄 UI/UX (Cambios visuales, animaciones)
- [ ] 🏗️ Refactor/Arquitectura

## 📸 Pruebas Visuales (Screenshots / GIFs)
<img width="339" height="115" alt="Screenshot 2026-03-30 at 10 47 33 AM" src="https://github.com/user-attachments/assets/b54991f7-b67d-4759-85b7-b6aac7a646a9" />

## ✅ Checklist (Criterios de Aceptación)
- [x] Mi código compila sin errores (`flutter run`).
- [x] Formateé el código con `dart format .`
- [x] No dejé `print()` sueltos (usé `debugPrint` si era estrictamente necesario).
- [ ] Probé la navegación hacia atrás (si aplica).