### PR TITLE
Shimmer of Decks completedk

### DIFF
--- a/lib/core/utils/color_constants.dart
+++ b/lib/core/utils/color_constants.dart
@@ -35,4 +35,8 @@ abstract class ColorConstants {
   static const Color iconNotSelected = Color(0xFF94A3B8);
   static const Color textMuted = Color(0xFF94A3B8);
   static const Color textDark = Color(0xFF334155);
+
+  // Animaciones
+  static const Color baseLoading = Color(0xFFE0E0E0);
+  static const Color highlightLoading = Color(0xFFF5F5F5);
 }

--- a/lib/features/deck/deck_screen.dart
+++ b/lib/features/deck/deck_screen.dart
@@ -7,6 +7,7 @@ import 'package:wize_cards/core/utils/icon_deck_by_tags.dart';
 import 'package:wize_cards/features/deck/bloc/deck_bloc.dart';
 import 'package:wize_cards/features/deck/constanst/deck_screen_constant.dart';
 import 'package:wize_cards/features/deck/widgets/deck_card_widget.dart';
+import 'package:wize_cards/features/deck/widgets/deck_shimmer_widget.dart';
 
 class DeckScreen extends StatelessWidget {
   const DeckScreen({super.key});
@@ -117,7 +118,7 @@ class DeckView extends StatelessWidget {
                 child: BlocBuilder<DeckBloc, DeckState>(
                   builder: (context, state) {
                     if (state.status == DeckStatus.loading) {
-                      return const Center(child: CircularProgressIndicator());
+                      return const Center(child: DeckShimmerWidget());
                     }
 
                     if (state.status == DeckStatus.failure) {

--- a/lib/features/deck/widgets/deck_shimmer_widget.dart
+++ b/lib/features/deck/widgets/deck_shimmer_widget.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+import 'package:wize_cards/core/utils/color_constants.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/features/deck/constanst/deck_screen_constant.dart';
+
+class DeckShimmerWidget extends StatelessWidget {
+  const DeckShimmerWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListView.builder(
+      physics: const NeverScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(SpacingConstants.small),
+      itemBuilder: (context, index) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: SpacingConstants.small),
+          child: Card(
+            margin: EdgeInsets.zero,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(BorderRadiusConstants.large),
+            ),
+            clipBehavior: Clip.antiAlias,
+            shadowColor: theme.shadowColor,
+            elevation: 1,
+            child: Shimmer.fromColors(
+              baseColor: ColorConstants.baseLoading,
+              highlightColor: ColorConstants.highlightLoading,
+              child: SizedBox(
+                height: DeckScreenConstants.sizeCard,
+                child: Column(
+                  children: [
+                    Spacer(),
+                    Padding(
+                      padding: const EdgeInsets.all(SpacingConstants.medium),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: ColorConstants.baseLoading,
+                              borderRadius: BorderRadius.circular(
+                                BorderRadiusConstants.medium,
+                              ),
+                            ),
+                            child: SizedBox(
+                              width: SizeConstants.cardSize,
+                              height: SizeConstants.cardSize,
+                            ),
+                          ),
+                    
+                          const SizedBox(width: SpacingConstants.medium),
+                    
+                          Expanded(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: ColorConstants.baseLoading,
+                                    borderRadius: BorderRadius.circular(
+                                      BorderRadiusConstants.small,
+                                    ),
+                                  ),
+                                  child: SizedBox(
+                                    width: double.infinity,
+                                    height: TextSizeConstants.subtitle,
+                                  ),
+                                ),
+                    
+                                const SizedBox(height: SpacingConstants.small),
+                    
+                                Row(
+                                  children: [
+                                    DecoratedBox(
+                                      decoration: BoxDecoration(
+                                        color: ColorConstants.baseLoading,
+                                        borderRadius: BorderRadius.circular(
+                                          BorderRadiusConstants.small,
+                                        ),
+                                      ),
+                                        child: Text(
+                                        '0 ${DeckScreenConstants.cards}',
+                                        style: theme.textTheme.bodyMedium?.copyWith(
+                                          fontWeight: FontWeight.w600,
+                                          fontSize: TextSizeConstants.body,
+                                        ),
+                                      ),
+                                    ),
+                    
+                                    const SizedBox(width: SpacingConstants.small),
+                    
+                                    DecoratedBox(
+                                      decoration: BoxDecoration(
+                                        color: ColorConstants.baseLoading,
+                                        borderRadius: BorderRadius.circular(
+                                          BorderRadiusConstants.small,
+                                        ),
+                                      ),
+                                        child: Text(
+                                          '• ${DeckScreenConstants.lastStudied}: Today',
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: theme.textTheme.bodyMedium?.copyWith(
+                                            fontSize: TextSizeConstants.body,
+                                          ),
+                                        )
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                    
+                          const SizedBox(width: SpacingConstants.small),
+                    
+                          Icon(
+                            Icons.chevron_right,
+                            color: theme.colorScheme.secondary,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Spacer(),
+                    DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: ColorConstants.baseLoading,
+                        borderRadius: BorderRadius.circular(
+                          BorderRadiusConstants.small,
+                        ),
+                      ),
+                      child: SizedBox(
+                        width: double.infinity,
+                        height: ThicknessConstans.md,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+    );
+  }
+}


### PR DESCRIPTION
## 🎯 ¿Qué hace este PR?
- Agrego shimmer a la vista de decks
- Referencia a este [PR](https://github.com/Stivenmore/Wize-Cards/pull/107), pero apuntando a la rama dev

## 🔗 Task Relacionada
Closes #96 

## 🛠️ Tipo de Cambio
- [x] ✨ Nueva Feature (Pantalla, Lógica, etc.)
- [ ] 🐛 Bugfix (Corrección de errores)
- [x] 💄 UI/UX (Cambios visuales, animaciones)
- [ ] 🏗️ Refactor/Arquitectura

## 📸 Pruebas Visuales (Screenshots / GIFs)

https://github.com/user-attachments/assets/823cafaa-739f-40f8-8054-15e94e736ff6

## ✅ Checklist (Criterios de Aceptación)
- [x] Mi código compila sin errores (`flutter run`).
- [x] Formateé el código con `dart format .`
- [x] No dejé `print()` sueltos (usé `debugPrint` si era estrictamente necesario).
- [x] Probé la navegación hacia atrás (si aplica).