### PR TITLE
feat: assemble stats screen with weekly activity, bar chart, stat car…

### DIFF
--- a/lib/features/stats/presentation/constants/stats_screen_constants.dart
+++ b/lib/features/stats/presentation/constants/stats_screen_constants.dart
@@ -7,6 +7,10 @@ abstract class StatsScreenConstants {
   static const Color trendPositiveColor = Color(0xFF16A34A);
   static const Color trendPositiveBackground = Color(0xFFF0FDF4);
 
+  // --- Spacing de la pantalla ---
+  static const double chartToCardsSpacing = 35.0;
+  static const double chartInternalTopPadding = 40.0;
+
   // --- Weekly bar chart ---
   static const double chartHeight = 128.0;
   static const int barMaxActions = 20;
@@ -31,4 +35,16 @@ abstract class StatsScreenConstants {
   // --- Tipografia de la stat card ---
   static const double statCardNumberLetterSpacing = -0.9;
   static const double statCardNumberLineHeight = 40.0;
+
+  // --- Colores de iconos de stat cards ---
+  static const Color fireIconColor = Color(0xFFF97316);
+
+  // --- Textos ---
+  static const String myProgressLabel = 'My Progress';
+  static const String weeklyActivityLabel = 'Weekly Activity';
+  static const String actionsLabel = 'actions';
+  static const String recentBadgesLabel = 'Recent Badges';
+  static const String viewAllLabel = 'View All';
+  static const String cardsCollectedLabel = 'Cards Collected';
+  static const String dayStreakLabel = 'Day Streak';
 }

--- a/lib/features/stats/presentation/stats_screen.dart
+++ b/lib/features/stats/presentation/stats_screen.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:wize_cards/core/utils/color_constants.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/features/stats/presentation/bloc/stats_bloc.dart';
+import 'package:wize_cards/features/stats/presentation/bloc/stats_event.dart';
+import 'package:wize_cards/features/stats/presentation/bloc/stats_state.dart';
+import 'package:wize_cards/features/stats/presentation/constants/stats_screen_constants.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/recent_badges_section.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/stat_card.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/weekly_activity_section.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/weekly_bar_chart.dart';
+
+/// Organismo: Pantalla principal de estadisticas "My Progress".
+///
+/// Ensambla todos los componentes de stats en una vista scrolleable
+/// conectada al StatsBloc.
+class StatsScreen extends StatefulWidget {
+  const StatsScreen({super.key});
+
+  @override
+  State<StatsScreen> createState() => _StatsScreenState();
+}
+
+class _StatsScreenState extends State<StatsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<StatsBloc>().add(StatsLoadRequested());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: ColorConstants.scaffoldBackground,
+      body: SafeArea(
+        child: BlocBuilder<StatsBloc, StatsState>(
+          builder: (context, state) {
+            if (state is StatsLoading || state is StatsInitial) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (state is StatsError) {
+              return Center(child: Text(state.message));
+            }
+
+            if (state is StatsLoaded) {
+              return _buildContent(context, state);
+            }
+
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, StatsLoaded state) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: SpacingConstants.large,
+        vertical: SpacingConstants.large,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            StatsScreenConstants.myProgressLabel,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          SizedBox(height: SpacingConstants.large),
+          WeeklyActivitySection(
+            weeklyActions: state.weeklyActions,
+            trendPercentage: state.trendPercentage,
+          ),
+          SizedBox(height: SpacingConstants.large),
+          WeeklyBarChart(
+            weeklyData: state.weeklyData,
+            currentDayIndex: state.currentDayIndex,
+          ),
+          SizedBox(height: StatsScreenConstants.chartToCardsSpacing),
+          Row(
+            spacing: SpacingConstants.small,
+            children: [
+              Expanded(
+                child: StatCard(
+                  value: state.cardsCollected,
+                  title: StatsScreenConstants.cardsCollectedLabel,
+                  iconPath: AppConstants.phoneIcon,
+                  iconColor: ColorConstants.primaryBlue,
+                ),
+              ),
+              Expanded(
+                child: StatCard(
+                  value: state.currentStreak,
+                  title: StatsScreenConstants.dayStreakLabel,
+                  iconPath: AppConstants.fireIcon,
+                  iconColor: StatsScreenConstants.fireIconColor,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: SpacingConstants.xLarge),
+          RecentBadgesSection(badges: state.badges),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/stats/presentation/stats_screen.dart
+++ b/lib/features/stats/presentation/stats_screen.dart
@@ -13,21 +13,22 @@ import 'package:wize_cards/features/stats/presentation/widgets/weekly_bar_chart.
 
 /// Organismo: Pantalla principal de estadisticas "My Progress".
 ///
-/// Ensambla todos los componentes de stats en una vista scrolleable
-/// conectada al StatsBloc.
-class StatsScreen extends StatefulWidget {
+/// Provee el StatsBloc al arbol de widgets y dispara el evento inicial
+/// de carga. El bloc vive solo mientras la pantalla este activa.
+class StatsScreen extends StatelessWidget {
   const StatsScreen({super.key});
 
   @override
-  State<StatsScreen> createState() => _StatsScreenState();
+  Widget build(BuildContext context) {
+    return BlocProvider<StatsBloc>(
+      create: (_) => StatsBloc()..add(StatsLoadRequested()),
+      child: const StatsView(),
+    );
+  }
 }
 
-class _StatsScreenState extends State<StatsScreen> {
-  @override
-  void initState() {
-    super.initState();
-    context.read<StatsBloc>().add(StatsLoadRequested());
-  }
+class StatsView extends StatelessWidget {
+  const StatsView({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/stats/presentation/widgets/recent_badges_section.dart
+++ b/lib/features/stats/presentation/widgets/recent_badges_section.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/data/models/badge_model.dart';
+import 'package:wize_cards/features/stats/presentation/constants/stats_screen_constants.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/achievement_badge.dart';
+
+/// Organismo: Seccion de badges recientes.
+///
+/// Muestra el titulo "Recent Badges" con boton "View All"
+/// y una fila de badges de logros.
+class RecentBadgesSection extends StatelessWidget {
+  const RecentBadgesSection({required this.badges, super.key});
+
+  final List<BadgeModel> badges;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              StatsScreenConstants.recentBadgesLabel,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            TextButton(
+              onPressed: () {},
+              child: Text(
+                StatsScreenConstants.viewAllLabel,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Theme.of(context).primaryColor,
+                ),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: SpacingConstants.small),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: badges
+              .map(
+                (badge) => AchievementBadge(
+                  iconPath: badge.iconPath,
+                  label: badge.label,
+                  color: badge.color,
+                  gradientColors: badge.gradientColors,
+                  isUnlocked: badge.isUnlocked,
+                ),
+              )
+              .toList(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stats/presentation/widgets/weekly_activity_section.dart
+++ b/lib/features/stats/presentation/widgets/weekly_activity_section.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:wize_cards/core/utils/constant.dart';
+import 'package:wize_cards/features/stats/presentation/constants/stats_screen_constants.dart';
+import 'package:wize_cards/features/stats/presentation/widgets/trend_pill.dart';
+
+/// Molecula: Seccion de actividad semanal.
+///
+/// Muestra el subtitulo "Weekly Activity", el numero de acciones
+/// y el indicador de tendencia porcentual.
+class WeeklyActivitySection extends StatelessWidget {
+  const WeeklyActivitySection({
+    required this.weeklyActions,
+    required this.trendPercentage,
+    super.key,
+  });
+
+  final int weeklyActions;
+  final int trendPercentage;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                StatsScreenConstants.weeklyActivityLabel,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      fontWeight: FontWeight.w500,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+              ),
+              SizedBox(height: SpacingConstants.xs),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.baseline,
+                textBaseline: TextBaseline.alphabetic,
+                spacing: SpacingConstants.small,
+                children: [
+                  Text(
+                    '$weeklyActions',
+                    style: Theme.of(context).textTheme.headlineLarge,
+                  ),
+                  Text(
+                    StatsScreenConstants.actionsLabel,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          fontWeight: FontWeight.w500,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        TrendPill(percentage: trendPercentage),
+      ],
+    );
+  }
+}

--- a/lib/features/stats/presentation/widgets/weekly_bar_chart.dart
+++ b/lib/features/stats/presentation/widgets/weekly_bar_chart.dart
@@ -20,9 +20,11 @@ class WeeklyBarChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: StatsScreenConstants.chartHeight,
-      child: Row(
+    return Padding(
+      padding: const EdgeInsets.only(top: StatsScreenConstants.chartInternalTopPadding),
+      child: SizedBox(
+        height: StatsScreenConstants.chartHeight,
+        child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: List.generate(weeklyData.length, (index) {
           return Expanded(
@@ -35,6 +37,7 @@ class WeeklyBarChart extends StatelessWidget {
             ),
           );
         }),
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,6 @@ import 'package:wize_cards/core/router/route_generator.dart';
 import 'package:wize_cards/core/theme/app_theme.dart';
 import 'package:wize_cards/core/di/injection_container.dart' as di;
 import 'package:wize_cards/features/auth/presentation/bloc/auth_bloc.dart';
-import 'package:wize_cards/features/stats/presentation/bloc/stats_bloc.dart';
 import 'package:wize_cards/firebase_options.dart';
 
 void main() async {
@@ -39,11 +38,8 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider<AuthBloc>.value(value: _authBloc),
-        BlocProvider<StatsBloc>(create: (_) => StatsBloc()),
-      ],
+    return BlocProvider<AuthBloc>.value(
+      value: _authBloc,
       child: useGoRouter
           ? MaterialApp.router(
               title: 'WizeCards',


### PR DESCRIPTION
## 🎯 ¿Qué hace este PR?
Ensambla la pantalla de Stats conectando todos los widgets atómicos existentes (WeeklyActivitySection, WeeklyBarChart, StatCards, RecentBadgesSection) con el StatsBloc para manejar el estado.

## 🔗 Task Relacionada
Closes #52

## 🛠️ Tipo de Cambio
- [x] ✨ Nueva Feature (Screen, Logic, etc.)
- [ ] 🐛 Bugfix (Corrección de errores)
- [ ] 💄 UI/UX (Cambios visuales, animaciones)
- [ ] 🏗️ Refactor/Architecture

## 📸 Pruebas Visuales
<img  height="700" alt="Simulator Screenshot - iPhone 16 Pro - 2026-04-01 at 11 50 18" src="https://github.com/user-attachments/assets/a19ef921-7dc2-4f17-8211-8475edd79913" />

## ✅ Checklist
- [x] El código compila sin errores (`flutter run`)
- [x] Código formateado con `dart format .`
- [x] No hay `print()` sueltos (usar `debugPrint` si es necesario)
- [ ] Navegación testeada hacia atrás (si aplica)